### PR TITLE
Add custom kind information to show where completions came from

### DIFF
--- a/lua/cmp_cmdline_history.lua
+++ b/lua/cmp_cmdline_history.lua
@@ -16,7 +16,14 @@ function source:complete(request, callback)
     local item = vim.fn.histget(hist_type, -i)
     if #item > 0 and not seen_items[item] then
       seen_items[item] = true
-      items[#items + 1] = { label = item, dup = 0 }
+      items[#items + 1] = {
+        label = item,
+        dup = 0,
+        cmp = {
+          kind_text = 'History',
+          kind_hl_group = 'CmpItemKindHistory'
+        }
+      }
     end
   end
   callback({ items = items })

--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -1,0 +1,1 @@
+vim.api.nvim_set_hl(0, 'CmpItemKindHistory', { link = 'CmpItemKind', default = true })


### PR DESCRIPTION
Also return a completion kind of `History` to show up as type information in the `nvim-cmp` popup, to show where these completions came from. This improves of the default where these just show up with the kind `Variable`.

I'm not sure I used the right place to initialize the new highlight group.